### PR TITLE
reference block methods for detail links

### DIFF
--- a/python/api/gluon/mxnet.gluon.HybridBlock.rst
+++ b/python/api/gluon/mxnet.gluon.HybridBlock.rst
@@ -4,7 +4,8 @@ HybridBlock
 .. currentmodule:: mxnet.gluon.nn
 
 .. autoclass:: HybridBlock
-
+   :members:
+   :inherited-members:
 
    HybridBlock inherits all methods and attributes from
    :py:class:`mxnet.gluon.nn.Block`. It adds the following additional methods:

--- a/python/api/gluon/mxnet.gluon.SymbolBlock.rst
+++ b/python/api/gluon/mxnet.gluon.SymbolBlock.rst
@@ -4,6 +4,8 @@ SymbolBlock
 .. currentmodule:: mxnet.gluon.nn
 
 .. autoclass:: SymbolBlock
+   :members:
+   :inherited-members:
 
    Besides the contruction method, SymbolBlock can be used as same as
    :py:class:`mxnet.gluon.nn.HybridBlock`.

--- a/python/api/gluon/mxnet.gluon.nn.Block.rst
+++ b/python/api/gluon/mxnet.gluon.nn.Block.rst
@@ -4,7 +4,8 @@ Block
 .. currentmodule:: mxnet.gluon.nn
 
 .. autoclass:: Block
-
+   :members:
+   :inherited-members:
 
    ..
       .. automethod:: __init__

--- a/python/api/gluon/mxnet.gluon.nn.HybridBlock.rst
+++ b/python/api/gluon/mxnet.gluon.nn.HybridBlock.rst
@@ -4,7 +4,8 @@ HybridBlock
 .. currentmodule:: mxnet.gluon.nn
 
 .. autoclass:: HybridBlock
-
+   :members:
+   :inherited-members:
 
    .. automethod:: __init__
 
@@ -14,25 +15,25 @@ HybridBlock
    .. autosummary::
 
       ~HybridBlock.__init__
-      ~Block.apply
-      ~Block.cast
-      ~Block.collect_params
+      ~HybridBlock.apply
+      ~HybridBlock.cast
+      ~HybridBlock.collect_params
       ~HybridBlock.export
-      ~Block.forward
+      ~HybridBlock.forward
       ~HybridBlock.hybrid_forward
       ~HybridBlock.hybridize
       ~HybridBlock.infer_shape
       ~HybridBlock.infer_type
-      ~Block.initialize
-      ~Block.load_parameters
-      ~Block.load_params
-      ~Block.name_scope
-      ~Block.register_child
-      ~Block.register_forward_hook
-      ~Block.register_forward_pre_hook
-      ~Block.save_parameters
-      ~Block.save_params
-      ~Block.summary
+      ~HybridBlock.initialize
+      ~HybridBlock.load_parameters
+      ~HybridBlock.load_params
+      ~HybridBlock.name_scope
+      ~HybridBlock.register_child
+      ~HybridBlock.register_forward_hook
+      ~HybridBlock.register_forward_pre_hook
+      ~HybridBlock.save_parameters
+      ~HybridBlock.save_params
+      ~HybridBlock.summary
 
 
 
@@ -42,9 +43,9 @@ HybridBlock
 
    .. autosummary::
 
-      ~Block.name
-      ~Block.params
-      ~Block.prefix
+      ~HybridBlock.name
+      ~HybridBlock.params
+      ~HybridBlock.prefix
 
 
 

--- a/python/api/gluon/mxnet.gluon.nn.HybridBlock.rst
+++ b/python/api/gluon/mxnet.gluon.nn.HybridBlock.rst
@@ -5,48 +5,48 @@ HybridBlock
 
 .. autoclass:: HybridBlock
 
-   
+
    .. automethod:: __init__
 
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~HybridBlock.__init__
-      ~HybridBlock.apply
-      ~HybridBlock.cast
-      ~HybridBlock.collect_params
+      ~Block.apply
+      ~Block.cast
+      ~Block.collect_params
       ~HybridBlock.export
-      ~HybridBlock.forward
+      ~Block.forward
       ~HybridBlock.hybrid_forward
       ~HybridBlock.hybridize
       ~HybridBlock.infer_shape
       ~HybridBlock.infer_type
-      ~HybridBlock.initialize
-      ~HybridBlock.load_parameters
-      ~HybridBlock.load_params
-      ~HybridBlock.name_scope
-      ~HybridBlock.register_child
-      ~HybridBlock.register_forward_hook
-      ~HybridBlock.register_forward_pre_hook
-      ~HybridBlock.save_parameters
-      ~HybridBlock.save_params
-      ~HybridBlock.summary
-   
-   
+      ~Block.initialize
+      ~Block.load_parameters
+      ~Block.load_params
+      ~Block.name_scope
+      ~Block.register_child
+      ~Block.register_forward_hook
+      ~Block.register_forward_pre_hook
+      ~Block.save_parameters
+      ~Block.save_params
+      ~Block.summary
 
-   
-   
+
+
+
+
    .. rubric:: Attributes
 
    .. autosummary::
-   
-      ~HybridBlock.name
-      ~HybridBlock.params
-      ~HybridBlock.prefix
-   
-   
+
+      ~Block.name
+      ~Block.params
+      ~Block.prefix
+
+
 
 .. disqus::
    :disqus_identifier: mxnet.gluon.nn.HybridBlock

--- a/python/api/gluon/mxnet.gluon.nn.SymbolBlock.rst
+++ b/python/api/gluon/mxnet.gluon.nn.SymbolBlock.rst
@@ -5,14 +5,15 @@ SymbolBlock
 
 .. autoclass:: SymbolBlock
 
-   
+   :members:
+   :inherited-members:   
    .. automethod:: __init__
 
-   
+
    .. rubric:: Methods
 
    .. autosummary::
-   
+
       ~SymbolBlock.__init__
       ~SymbolBlock.apply
       ~SymbolBlock.cast
@@ -34,20 +35,20 @@ SymbolBlock
       ~SymbolBlock.save_parameters
       ~SymbolBlock.save_params
       ~SymbolBlock.summary
-   
-   
 
-   
-   
+
+
+
+
    .. rubric:: Attributes
 
    .. autosummary::
-   
+
       ~SymbolBlock.name
       ~SymbolBlock.params
       ~SymbolBlock.prefix
-   
-   
+
+
 
 .. disqus::
    :disqus_identifier: mxnet.gluon.nn.SymbolBlock


### PR DESCRIPTION
In [HybridBlock](https://beta.mxnet.io/api/gluon/mxnet.gluon.nn.HybridBlock.html), many of the methods do not show a link, so I set these to display Block instead, where a link with detailed usage is available.

I do wonder if there's a way to show this difference - the fact that some methods are inherited and some are extended. 

**Note**: having the functions link to detailed descriptions is very important, however, at this moment there are over 100k warnings or errors from Sphinx on how the docs are generated (not related to this PR). The site won't make it to production in this state, and it makes it really hard to see if we're doing things right when making changes like in this PR. 