### PR TITLE
remove random.seed to get rid of errors

### DIFF
--- a/python/api/ndarray/routines.rst
+++ b/python/api/ndarray/routines.rst
@@ -292,7 +292,6 @@ Random Distribution
     random.randn
     random.shuffle
     random.uniform
-    mxnet.random.seed
 
 Linear Algebra
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This is a response to #80. I tried `random.seed` and that didn't work either. So we'll need to add it back at some point, but these gets rid about about 2k errors so we can focus on other issues.