### PR TITLE
new gluon api landing page

### DIFF
--- a/python/api/gluon/index.rst
+++ b/python/api/gluon/index.rst
@@ -2,6 +2,7 @@ mxnet.gluon
 =======================
 
 .. toctree::
+   :hidden:
    :maxdepth: 2
 
    nn
@@ -13,5 +14,92 @@ mxnet.gluon
    mxnet.gluon.data.vision
    mxnet.gluon.model_zoo
    mxnet.gluon.utils
+
+
+.. container:: cards
+
+   .. card::
+      :title: Gluon Tutorials
+      :link: ../../guide/packages/gluon/
+
+      The Gluon guide.
+
+   .. card::
+      :title: Gluon-CV Toolkit
+      :link: https://gluon-cv.mxnet.io/
+
+      A Gluon add-on module for computer vision.
+
+   .. card::
+      :title: Gluon-NLP Toolkit
+      :link: https://gluon-nlp.mxnet.io/
+
+      A Gluon add-on module for natural language processing.
+
+
+.. container:: cards
+
+   .. card::
+      :title: gluon.nn
+      :link: nn/
+
+      Neural network components.
+
+   .. card::
+      :title: gluon.rnn
+      :link: nn/
+
+      Recurrent neural network components.
+
+
+.. container:: cards
+
+   .. card::
+      :title: gluon.loss
+      :link: mxnet.gluon.loss.html
+
+      Loss functions for training neural networks.
+
+   .. card::
+      :title: gluon.parameter
+      :link: mxnet.gluon.parameter.html
+
+      Parameter getting and setting functions.
+
+   .. card::
+      :title: gluon.Trainer
+      :link: mxnet.gluon.trainer.html
+
+      Functions for applying an optimizer on a set of parameters.
+
+
+.. container:: cards
+
+   .. card::
+      :title: gluon.data
+      :link: mxnet.gluon.data.html
+
+      Dataset utilities.
+
+   .. card::
+      :title: gluon.data.vision
+      :link: mxnet.gluon.data.vision.html
+
+      Image dataset utilities.
+
+   .. card::
+      :title: gluon.model_zoo.vision
+      :link: mxnet.gluon.model_zoo.vision.html
+
+      A module for loading pre-trained neural network models.
+
+
+.. container:: cards
+
+   .. card::
+      :title: gluon.utils
+      :link: mxnet.gluon.utils.html
+
+      A variety of utilities for training.
 
 .. disqus::

--- a/python/api/gluon/index.rst
+++ b/python/api/gluon/index.rst
@@ -1,28 +1,37 @@
 mxnet.gluon
 =======================
 
-.. toctree::
-   :hidden:
-   :maxdepth: 2
+The Gluon library in Apache MXNet provides a clear, concise, and simple API for deep learning.
+It makes it easy to prototype, build, and train deep learning models without sacrificing training speed.
 
-   nn
-   rnn
-   mxnet.gluon.loss
-   mxnet.gluon.parameter
-   mxnet.gluon.Trainer
-   mxnet.gluon.data
-   mxnet.gluon.data.vision
-   mxnet.gluon.model_zoo
-   mxnet.gluon.utils
+Example
+-------
 
+The following example shows how you might create a simple neural network with three layers:
+one input layer, one hidden layer, and one output layer.
+
+.. code-block:: python
+
+   net = gluon.nn.Sequential()
+   # When instantiated, Sequential stores a chain of neural network layers.
+   # Once presented with data, Sequential executes each layer in turn, using
+   # the output of one layer as the input for the next
+   with net.name_scope():
+       net.add(gluon.nn.Dense(256, activation="relu")) # 1st layer (256 nodes)
+       net.add(gluon.nn.Dense(256, activation="relu")) # 2nd hidden layer
+       net.add(gluon.nn.Dense(num_outputs))
+
+
+Tutorials
+---------
 
 .. container:: cards
 
    .. card::
-      :title: Gluon Tutorials
+      :title: Gluon Guide
       :link: ../../guide/packages/gluon/
 
-      The Gluon guide.
+      The Gluon guide. Start here!
 
    .. card::
       :title: Gluon-CV Toolkit
@@ -36,6 +45,12 @@ mxnet.gluon
 
       A Gluon add-on module for natural language processing.
 
+
+APIs and Packages
+-----------------
+
+Core Modules
+~~~~~~~~~~~~
 
 .. container:: cards
 
@@ -51,6 +66,8 @@ mxnet.gluon
 
       Recurrent neural network components.
 
+Training
+~~~~~~~~
 
 .. container:: cards
 
@@ -72,6 +89,8 @@ mxnet.gluon
 
       Functions for applying an optimizer on a set of parameters.
 
+Data
+~~~~
 
 .. container:: cards
 
@@ -94,6 +113,9 @@ mxnet.gluon
       A module for loading pre-trained neural network models.
 
 
+Utilities
+~~~~~~~~~
+
 .. container:: cards
 
    .. card::
@@ -103,3 +125,17 @@ mxnet.gluon
       A variety of utilities for training.
 
 .. disqus::
+
+.. toctree::
+   :hidden:
+   :maxdepth: 2
+
+   nn
+   rnn
+   mxnet.gluon.loss
+   mxnet.gluon.parameter
+   mxnet.gluon.Trainer
+   mxnet.gluon.data
+   mxnet.gluon.data.vision
+   mxnet.gluon.model_zoo
+   mxnet.gluon.utils


### PR DESCRIPTION
The current landing pages are just a dump of the ToC, and pretty hard to read. Also we don't cross-reference tutorials. This PR fixes that for the Gluon API.
Preview: http://204.236.210.14/api/gluon/index.html

The structure that I went for here is close to the wireframe. You can envision each container might get a custom class and we'd have different card types, so that the UX and design can be updated seamlessly later.

* [wireframe for gluon API landing page](https://gallery.io/projects/MCHbtQVoQ2HCZfrqGyueCUJz/files/MCEJu8Y2hyDSce1jUXa_Q3sY-VWY4FYHvrk)

I'd prefer if the toc dump would be nicely formatted, but it is not. A theme issue. So I put each API in its own card. You'll note that I don't have an example or top description in here at this point.

-Related Content Container 
  --tutorials
  --ecosystem item
  --ecosystem item
  --[more cards]
-Core API Container
  --card
  --card
  --[more cards]
-Detail API Container
  --card
  --card
  --[more cards]
-Related API Container
  --card
  --card
  --[more cards]



